### PR TITLE
Django-allauth-ui updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ whitenoise
 django-allauth[socialaccount]
 django-allauth-ui
 django-widget-tweaks
+slippers
 stripe

--- a/src/cfehome/settings.py
+++ b/src/cfehome/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/5.0/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.0/ref/settings/
 """
+
 from decouple import config
 from pathlib import Path
 
@@ -20,41 +21,41 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Email config
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_HOST = config("EMAIL_HOST", cast=str, default="smtp.gmail.com")
-EMAIL_PORT = config("EMAIL_PORT", cast=str, default="587") # Recommended
+EMAIL_PORT = config("EMAIL_PORT", cast=str, default="587")  # Recommended
 EMAIL_HOST_USER = config("EMAIL_HOST_USER", cast=str, default=None)
 EMAIL_HOST_PASSWORD = config("EMAIL_HOST_PASSWORD", cast=str, default=None)
-EMAIL_USE_TLS = config("EMAIL_USE_TLS", cast=bool, default=True)  # Use EMAIL_PORT 587 for TLS
-EMAIL_USE_SSL = config("EMAIL_USE_SSL", cast=bool, default=False)  # Use MAIL_PORT 465 for SSL
-ADMIN_USER_NAME=config("ADMIN_USER_NAME", default="Admin user")
-ADMIN_USER_EMAIL=config("ADMIN_USER_EMAIL", default=None)
+EMAIL_USE_TLS = config(
+    "EMAIL_USE_TLS", cast=bool, default=True
+)  # Use EMAIL_PORT 587 for TLS
+EMAIL_USE_SSL = config(
+    "EMAIL_USE_SSL", cast=bool, default=False
+)  # Use MAIL_PORT 465 for SSL
+ADMIN_USER_NAME = config("ADMIN_USER_NAME", default="Admin user")
+ADMIN_USER_EMAIL = config("ADMIN_USER_EMAIL", default=None)
 
-MANAGERS=[]
-ADMINS=[]
+
+print(f"EMAIL_USE_SSL: {EMAIL_USE_SSL}")
+
+MANAGERS = []
+ADMINS = []
 if all([ADMIN_USER_NAME, ADMIN_USER_EMAIL]):
     # 500 errors are emailed to these users
-    ADMINS +=[
-        (f'{ADMIN_USER_NAME}', f'{ADMIN_USER_EMAIL}')
-    ]
-    MANAGERS=ADMINS
+    ADMINS += [(f"{ADMIN_USER_NAME}", f"{ADMIN_USER_EMAIL}")]
+    MANAGERS = ADMINS
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = config("DJANGO_SECRET_KEY") 
+SECRET_KEY = config("DJANGO_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 # DEBUG = str(os.environ.get("DJANGO_DEBUG")).lower() == "true"
 DEBUG = config("DJANGO_DEBUG", cast=bool)
 BASE_URL = config("BASE_URL", default=None)
-ALLOWED_HOSTS = [
-    ".railway.app" # https://saas.prod.railway.app
-]
+ALLOWED_HOSTS = [".railway.app"]  # https://saas.prod.railway.app
 if DEBUG:
-    ALLOWED_HOSTS += [
-        "127.0.0.1",
-        "localhost"
-    ]
+    ALLOWED_HOSTS += ["127.0.0.1", "localhost"]
 
 
 # Application definition
@@ -75,11 +76,12 @@ INSTALLED_APPS = [
     "visits",
     # third-party-apps
     "allauth_ui",
-    'allauth',
-    'allauth.account',
-    'allauth.socialaccount',
-    'allauth.socialaccount.providers.github',
+    "allauth",
+    "allauth.account",
+    "allauth.socialaccount",
+    "allauth.socialaccount.providers.github",
     "widget_tweaks",
+    "slippers",
 ]
 
 MIDDLEWARE = [
@@ -130,6 +132,7 @@ DATABASE_URL = config("DATABASE_URL", default=None)
 
 if DATABASE_URL is not None:
     import dj_database_url
+
     DATABASES = {
         "default": dj_database_url.config(
             default=DATABASE_URL,
@@ -176,28 +179,23 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-# Django Allauth Config 
+# Django Allauth Config
 LOGIN_REDIRECT_URL = "/"
 ACCOUNT_AUTHENTICATION_METHOD = "username_email"
-ACCOUNT_EMAIL_VERIFICATION="mandatory"
-ACCOUNT_EMAIL_SUBJECT_PREFIX="[CFE] "
-ACCOUNT_EMAIL_REQUIRED=True
+ACCOUNT_EMAIL_VERIFICATION = "mandatory"
+ACCOUNT_EMAIL_SUBJECT_PREFIX = "[CFE] "
+ACCOUNT_EMAIL_REQUIRED = True
 
 AUTHENTICATION_BACKENDS = [
     # ...
     # Needed to login by username in Django admin, regardless of `allauth`
-    'django.contrib.auth.backends.ModelBackend',
-
+    "django.contrib.auth.backends.ModelBackend",
     # `allauth` specific authentication methods, such as login by email
-    'allauth.account.auth_backends.AuthenticationBackend',
+    "allauth.account.auth_backends.AuthenticationBackend",
     # ...
 ]
 
-SOCIALACCOUNT_PROVIDERS = {
-    "github": {
-        "VERIFIED_EMAIL": True
-    }
-}
+SOCIALACCOUNT_PROVIDERS = {"github": {"VERIFIED_EMAIL": True}}
 
 
 # Internationalization
@@ -220,12 +218,10 @@ STATICFILES_BASE_DIR = BASE_DIR / "staticfiles"
 STATICFILES_BASE_DIR.mkdir(exist_ok=True, parents=True)
 STATICFILES_VENDOR_DIR = STATICFILES_BASE_DIR / "vendors"
 
-# source(s) for python manage.py collectstatic 
-STATICFILES_DIRS = [
-    STATICFILES_BASE_DIR
-]
+# source(s) for python manage.py collectstatic
+STATICFILES_DIRS = [STATICFILES_BASE_DIR]
 
-# output for python manage.py collectstatic 
+# output for python manage.py collectstatic
 # local cdn
 STATIC_ROOT = BASE_DIR / "local-cdn"
 

--- a/src/templates/account/login.html
+++ b/src/templates/account/login.html
@@ -1,0 +1,40 @@
+{% extends "account/login.html" %}
+{% load i18n %}
+{% load allauth_ui %}
+{% load widget_tweaks %}
+{% block content %}
+{% include 'nav/navbar.html' %}
+{% include 'base/css.html' %}
+{% load static %}
+    {% trans "Sign In" as heading %}
+    {% #container heading=heading  %}
+    {% if not SOCIALACCOUNT_ONLY %}
+        <div class="py-3">
+            {% blocktranslate %}If you have not created an account yet, then please
+		    <a class="link" href="{{ signup_url }}">sign up</a> first.{% endblocktranslate %}
+        </div>
+        {% url 'account_login' as action_url %}
+        {% #form form=form url=action_url button_text=heading %}
+        <div class="items-start my-2 form-control">
+            <label class="cursor-pointer label">
+                {% render_field form.remember class="checkbox checkbox-accent" %}
+                <span class="ml-2 label-text">Remember me</span>
+            </label>
+        </div>
+        {{ redirect_field }}
+        {% csrf_token %}
+        <div class="flex flex-col">
+            <a class="link self-end text-sm"
+               href="{% url "account_reset_password" %}">Forgot password?</a>
+        </div>
+        {% /form %}
+    {% endif %}
+    {% if LOGIN_BY_CODE_ENABLED %}
+        <div class="divider divider-neutral"></div>
+        <a href="{{ request_login_code_url }}" class="btn btn-neutral">{% trans "Mail me a sign-in code" %}</a>
+    {% endif %}
+    {% if SOCIALACCOUNT_ENABLED %}
+        {% include "socialaccount/snippets/login.html" with page_layout="entrance" %}
+    {% endif %}
+    {% /container %}
+{% endblock content %}

--- a/src/templates/account/logout.html
+++ b/src/templates/account/logout.html
@@ -1,13 +1,17 @@
-{% extends "account/base.html" %}
+{% extends "account/logout.html" %}
 {% load i18n %}
-{% block head_title %}
-    {% translate "Sign out" %}
-{% endblock %}
-{% block whitebox %}
-    <form method="post" action="{% url 'account_logout' %}">
-        {% csrf_token %}
-        <p>{% translate "Are you sure you want to sign out?" %}</p>
-        {% translate "Sign out" as signout_message %}
-        {% include "account/_button.html" with text=signout_message %}
-    </form>
-{% endblock %}
+{% load allauth_ui %}
+{% block content %}
+  {% include 'nav/navbar.html' %}
+  {% include 'base/css.html' %}
+    {% trans "Sign Out" as heading %}
+    {% trans "Are you sure you want to sign out?" as subheading %}
+    {% url 'account_logout' as action_url %}
+    {% #container heading=heading subheading=subheading %}
+    {% trans "Continue" as button_text %}
+    {% #form url=action_url button_text=heading %}
+    {% csrf_token %}
+    {{ redirect_field }}
+    {% /form %}
+    {% /container %}
+{% endblock content %}

--- a/src/templates/account/signup.html
+++ b/src/templates/account/signup.html
@@ -1,0 +1,22 @@
+{% extends "account/signup.html" %}
+{% load i18n %}
+{% load allauth_ui %}
+{% load widget_tweaks %}
+{% block content %}
+    {% include 'nav/navbar.html' %}
+    {% include 'base/css.html' %}
+    {% trans "Sign Up" as heading %}
+    {% blocktranslate asvar subheading %}Already have an account? Then please <a href="{{ login_url }}" class="link">sign in</a>.{% endblocktranslate %}
+    {% #container heading=heading subheading=subheading  %}
+    {% if not SOCIALACCOUNT_ONLY %}
+        {% url 'account_signup' as action_url %}
+        {% #form form=form url=action_url button_text=heading %}
+        {{ redirect_field }}
+        {% csrf_token %}
+        {% /form %}
+    {% endif %}
+    {% if SOCIALACCOUNT_ENABLED %}
+        {% include "socialaccount/snippets/login.html" with page_layout="entrance" %}
+    {% endif %}
+    {% /container %}
+{% endblock %}


### PR DESCRIPTION
Django-allauth-ui updated where it looks for some of these files. And you now need slippers as an app for this to work correctly.

There is also an error when trying to handle the new user signup verification email.
SSLCertVerificationError at /accounts/signup/
[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1000)

I have not debugged this one yet though since I do not need that for my application. 

Also sorry for black automatically reformatting some of the files, but also you should definitely use that extension. 