### PR TITLE
Fix email verification

### DIFF
--- a/src/customers/models.py
+++ b/src/customers/models.py
@@ -22,7 +22,7 @@ class Customer(models.Model):
         if not self.stripe_id:
             if self.init_email_confirmed and self.init_email:
                 email = self.init_email
-                if email != "" or email is not None:
+                if email != "" and email is not None:
                     stripe_id = helpers.billing.create_customer(email=email,metadata={
                         "user_id": self.user.id, 
                         "username": self.user.username


### PR DESCRIPTION
Just a small fix on the e-mail verification.
When transforming the assertion to a negation, the "or" should have become an "and".
I haven't changed the end of the file, but github insists on including that. I believe is something related to line end characters. 